### PR TITLE
Remove invalid spec.istio config

### DIFF
--- a/.nais/naiserator.yaml
+++ b/.nais/naiserator.yaml
@@ -27,8 +27,6 @@ spec:
   leaderElection: false
   prometheus:
     path: /internal/prometheus
-  istio:
-    enabled: false
   resources:
     limits:
       cpu: 400m


### PR DESCRIPTION
Fixes error message `unknown field "spec.istio"; it might be misspelled or incorrectly indented, or unsupported by the resource API specifications.`