### PR TITLE
Kartlegging svar

### DIFF
--- a/data/kartlegging/receipt.json
+++ b/data/kartlegging/receipt.json
@@ -21,8 +21,8 @@
         "description": null,
         "fieldId": "samarbeidOgRelasjonTilArbeidsgiver",
         "options": [
-          { "optionId": "2a", "optionLabel": "Jeg opplever forholdet vårt som godt", "wasSelected": true },
-          { "optionId": "2b", "optionLabel": "Jeg opplever ikke forholdet vårt som godt", "wasSelected": false }
+          { "optionId": "2a", "optionLabel": "Jeg opplever forholdet vårt som godt", "wasSelected": false },
+          { "optionId": "2b", "optionLabel": "Jeg opplever ikke forholdet vårt som godt", "wasSelected": true }
         ]
       },
       {
@@ -32,8 +32,8 @@
         "description": null,
         "fieldId": "naarTilbakeTilJobben",
         "options": [
-          { "optionId": "3a", "optionLabel": "Mindre enn 26 uker (6 måneder) totalt", "wasSelected": true },
-          { "optionId": "3b", "optionLabel": "Mer enn 26 uker (6 måneder) totalt", "wasSelected": false }
+          { "optionId": "3a", "optionLabel": "Mindre enn 26 uker (6 måneder) totalt", "wasSelected": false },
+          { "optionId": "3b", "optionLabel": "Mer enn 26 uker (6 måneder) totalt", "wasSelected": true }
         ]
       }
     ]

--- a/data/kartlegging/receipt.json
+++ b/data/kartlegging/receipt.json
@@ -1,0 +1,41 @@
+{
+  "brevdata": {
+    "createdAt": "01.09.2025",
+    "fieldSnapshots": [
+      {
+        "fieldType": "RADIO_GROUP",
+        "label": "Hvor sannsynlig er det at du kommer tilbake i jobben du ble sykmeldt fra?",
+        "wasRequired": true,
+        "description": null,
+        "fieldId": "hvorSannsynligTilbakeTilJobben",
+        "options": [
+          { "optionId": "1a", "optionLabel": "Jeg tror det er veldig sannsynlig", "wasSelected": true },
+          { "optionId": "1b", "optionLabel": "Jeg tror det er lite sannsynlig", "wasSelected": false },
+          { "optionId": "1c", "optionLabel": "Jeg er usikker", "wasSelected": false }
+        ]
+      },
+      {
+        "fieldType": "RADIO_GROUP",
+        "label": "Hvordan vil du beskrive samarbeidet og relasjonen mellom deg og arbeidsgiveren din?",
+        "wasRequired": true,
+        "description": null,
+        "fieldId": "samarbeidOgRelasjonTilArbeidsgiver",
+        "options": [
+          { "optionId": "2a", "optionLabel": "Jeg opplever forholdet vårt som godt", "wasSelected": true },
+          { "optionId": "2b", "optionLabel": "Jeg opplever ikke forholdet vårt som godt", "wasSelected": false }
+        ]
+      },
+      {
+        "fieldType": "RADIO_GROUP",
+        "label": "Hvor lenge tror du at du har behov for å være sykmeldt?",
+        "wasRequired": true,
+        "description": null,
+        "fieldId": "naarTilbakeTilJobben",
+        "options": [
+          { "optionId": "3a", "optionLabel": "Mindre enn 26 uker (6 måneder) totalt", "wasSelected": true },
+          { "optionId": "3b", "optionLabel": "Mer enn 26 uker (6 måneder) totalt", "wasSelected": false }
+        ]
+      }
+    ]
+  }
+}

--- a/templates/kartlegging/partials/radioButton.hbs
+++ b/templates/kartlegging/partials/radioButton.hbs
@@ -1,0 +1,11 @@
+<div>
+  {{#eq value checkedIfValueEquals }}
+    <img alt="checked radio-button" class="radio-button-image" src="{{ image "radio-button-checked.svg" }} "/>
+  {{/eq}}
+  
+  {{#not_eq value checkedIfValueEquals }}
+    <img alt="unchecked radio-button" class="radio-button-image" src="{{ image "radio-button.svg" }} "/>
+  {{/not_eq}}
+
+  <span class="radio-button-label">{{ label }}{{#eq value checkedIfValueEquals }} <span class="selected-option-help-text">(du valgte dette alternativet)</span>{{/eq}}</span>
+</div>

--- a/templates/kartlegging/receipt.hbs
+++ b/templates/kartlegging/receipt.hbs
@@ -17,7 +17,6 @@
         .question-block { margin: 0 0 1.25rem 0; }
         .question-label { margin: 0 0 0.5rem 0; font-weight: 600; }
         .info-box { border-style: solid; border-radius: 4px; padding: 0.25rem 1rem; background-color: rgb(204, 241, 214); }
-        .muted { color: #6A6A6A; font-size: 14px; line-height: 20px; }
         /* Radio button visual container to mirror senoppfolging style */
         .radio-buttons-container > * { margin-bottom: 0.5rem; }
         .radio-buttons-container img.radio-button-image { height: 1.5rem; float: left; display: inline-block; margin-right: 0.25rem; }
@@ -37,29 +36,21 @@
     </div>
     <h2>Oppsummering av dine svar</h2>
     <div class="summary-container">
-        {{#if brevdata.fieldSnapshots}}
-            {{#each brevdata.fieldSnapshots}}
-                <div class="question-block">
-                    <p class="question-label">{{label}}</p>
-                    {{#if options}}
-                        <div class="radio-buttons-container">
-                            {{#each options}}
-                                {{#if wasSelected}}
-                                    {{> kartlegging/partials/radioButton value="SELECTED" checkedIfValueEquals="SELECTED" label=optionLabel }}
-                                {{else}}
-                                    {{> kartlegging/partials/radioButton value="NOT_SELECTED" checkedIfValueEquals="SELECTED" label=optionLabel }}
-                                {{/if}}
-                            {{/each}}
-                        </div>
-                    {{else}}
-                        <p class="muted">(Ingen alternativer)</p>
-                    {{/if}}
+        {{#each brevdata.fieldSnapshots}}
+            <div class="question-block">
+                <p class="question-label">{{label}}</p>
+                <div class="radio-buttons-container">
+                    {{#each options}}
+                        {{#if wasSelected}}
+                            {{> kartlegging/partials/radioButton value="SELECTED" checkedIfValueEquals="SELECTED" label=optionLabel }}
+                        {{else}}
+                            {{> kartlegging/partials/radioButton value="NOT_SELECTED" checkedIfValueEquals="SELECTED" label=optionLabel }}
+                        {{/if}}
+                    {{/each}}
                 </div>
-                {{#unless @last}}<hr class="question-separator" />{{/unless}}
-            {{/each}}
-        {{else}}
-            <p class="muted">Ingen spørsmål å vise.</p>
-        {{/if}}
+            </div>
+            {{#unless @last}}<hr class="question-separator" />{{/unless}}
+        {{/each}}
     </div>
 </body>
 </html>

--- a/templates/kartlegging/receipt.hbs
+++ b/templates/kartlegging/receipt.hbs
@@ -41,11 +41,7 @@
                 <p class="question-label">{{label}}</p>
                 <div class="radio-buttons-container">
                     {{#each options}}
-                        {{#if wasSelected}}
-                            {{> kartlegging/partials/radioButton value="SELECTED" checkedIfValueEquals="SELECTED" label=optionLabel }}
-                        {{else}}
-                            {{> kartlegging/partials/radioButton value="NOT_SELECTED" checkedIfValueEquals="SELECTED" label=optionLabel }}
-                        {{/if}}
+                        {{> kartlegging/partials/radioButton value=wasSelected checkedIfValueEquals="true" label=optionLabel }}
                     {{/each}}
                 </div>
             </div>

--- a/templates/kartlegging/receipt.hbs
+++ b/templates/kartlegging/receipt.hbs
@@ -1,0 +1,65 @@
+<!DOCTYPE html>
+<html lang="no">
+<head>
+    <meta charset="UTF-8" />
+    <meta name="description" content="Kartlegging – Kvittering på ditt svar" />
+    <meta name="author" content="syfooppdfgen"/>
+    <meta name="subject" content="Kartlegging"/>
+    <title>Kartlegging – Kvittering på ditt svar</title>
+    <style>
+        * { font-family: "Source Sans Pro", SourceSansPro, Source_Sans_Pro, ArialSystem, sans-serif; color: #262626; font-style: normal; font-size: 18px; font-weight: 400; line-height: 28px; }
+        h1, h2 { font-weight: 600; page-break-after: avoid; }
+        h1 { font-size: 32px; line-height: 40px; }
+        h2 { font-size: 20px; line-height: 20px; }
+        a { color: rgb(0, 103, 197); }
+        .text--bold { font-weight: 600; }
+        .summary-container { border-radius: 4px; padding: 0.25rem 1rem; }
+        .question-block { margin: 0 0 1.25rem 0; }
+        .question-label { margin: 0 0 0.5rem 0; font-weight: 600; }
+        .info-box { border-style: solid; border-radius: 4px; padding: 0.25rem 1rem; background-color: rgb(204, 241, 214); }
+        .muted { color: #6A6A6A; font-size: 14px; line-height: 20px; }
+        /* Radio button visual container to mirror senoppfolging style */
+        .radio-buttons-container > * { margin-bottom: 0.5rem; }
+        .radio-buttons-container img.radio-button-image { height: 1.5rem; float: left; display: inline-block; margin-right: 0.25rem; }
+        .radio-buttons-container .radio-button-label .selected-option-help-text { color: #00459C; }
+        .question-separator { border: none; border-top: 1px solid #D2D2D2; margin: 1rem 0; }
+    </style>
+</head>
+<body style="page-break-inside: avoid;">
+    <h1>Din situasjon – behovsrettet oppfølging</h1>
+    <p>Du har vært sykmeldt en stund, og vi ønsker å følge deg opp på best mulig måte. Derfor ber vi deg svare på tre
+        korte spørsmål om din situasjon. Spørsmålene hjelper oss med å gi deg riktig støtte videre, og svarene dine blir
+        sett av veilederen din ved ditt Nav-kontor.
+    </p>
+    <div class="info-box">
+        <p class="text--bold" style="margin: 0 0 0.25rem 0">Takk, svarene dine er sendt til Nav.</p>
+        <p style="margin: 0">Motatt: {{ brevdata.createdAt }}</p>
+    </div>
+    <h2>Oppsummering av dine svar</h2>
+    <div class="summary-container">
+        {{#if brevdata.fieldSnapshots}}
+            {{#each brevdata.fieldSnapshots}}
+                <div class="question-block">
+                    <p class="question-label">{{label}}</p>
+                    {{#if options}}
+                        <div class="radio-buttons-container">
+                            {{#each options}}
+                                {{#if wasSelected}}
+                                    {{> kartlegging/partials/radioButton value="SELECTED" checkedIfValueEquals="SELECTED" label=optionLabel }}
+                                {{else}}
+                                    {{> kartlegging/partials/radioButton value="NOT_SELECTED" checkedIfValueEquals="SELECTED" label=optionLabel }}
+                                {{/if}}
+                            {{/each}}
+                        </div>
+                    {{else}}
+                        <p class="muted">(Ingen alternativer)</p>
+                    {{/if}}
+                </div>
+                {{#unless @last}}<hr class="question-separator" />{{/unless}}
+            {{/each}}
+        {{else}}
+            <p class="muted">Ingen spørsmål å vise.</p>
+        {{/if}}
+    </div>
+</body>
+</html>


### PR DESCRIPTION
Dokument for journalføring etter at bruker har svart på kartleggingsspørsmål.
Kan testes ved å kjøres opp lokalt og navigere til /api/v1/genpdf/kartlegging/receipt
Resultat:
[document.pdf](https://github.com/user-attachments/files/22660758/document.pdf)
