### PR TITLE
IS-3813: update text utsending.hbs

### DIFF
--- a/templates/kartlegging/utsending.hbs
+++ b/templates/kartlegging/utsending.hbs
@@ -30,12 +30,11 @@
     <h1>Kartlegging av din situasjon</h1>
     <p>
         Siden du har vært sykmeldt en stund, ønsker vi å få bedre kjennskap til
-        din situasjon ved at du svarer på disse tre spørsmålene. Dette gir Nav en
-        bedre forståelse av om vi skal gi deg oppfølging i tillegg til den du
-        skal få fra arbeidsgiveren din.
+        din situasjon ved at du svarer på disse tre spørsmålene. Dette gir Nav innsikt
+        i hvordan vi kan følge deg opp fremover.
       </p>
     <p>
-        Svarene dine blir kun delt med Nav.
+        Svarene blir kun delt med Nav og ikke din arbeidsgiver.
     </p>
 
     <div class="summary-container">
@@ -79,7 +78,7 @@
                     label="Jeg opplever samarbeidet og relasjonen som dårlig"
             }}
         </div>
-        
+
         <hr class="question-separator" />
 
         <p class="question-label">


### PR DESCRIPTION
Oppdatert til å følge nye skisser. Dette er da PDF som sendes ut når varselet går til sykmeldt. PDF for kvittering oppdateres dymisk etter hva som har blitt sendt inn, og krever derfor ikke tekstendringer. 

NB! Må merges sammen med endringer i bro-frontend (som også omfatter støtte for fritekstfelt).

<img width="995" height="1237" alt="Skjermbilde 2026-03-27 kl  09 03 08" src="https://github.com/user-attachments/assets/19956a3f-48ad-4904-9094-24eee99fef8c" />
