### PR TITLE
feat: vis stilling i oppfolgingsplan-pdf

### DIFF
--- a/data/oppfolgingsplan/oppfolgingsplan_v1.json
+++ b/data/oppfolgingsplan/oppfolgingsplan_v1.json
@@ -7,6 +7,8 @@
     "sykmeldtFnr": "12345678901",
     "organisasjonsnavn": "Eksempel AS",
     "organisasjonsnummer": "987654321",
+    "stillingstittel": "Brødkontroller",
+    "stillingsprosent": "50",
     "narmesteLederName": "Leder Larsen",
     "sections": [
       {

--- a/templates/oppfolgingsplan/oppfolgingsplan_v1.hbs
+++ b/templates/oppfolgingsplan/oppfolgingsplan_v1.hbs
@@ -42,11 +42,11 @@
 
 <p><strong>Opprettet:</strong> {{oppfolgingsplan.createdDate}}</p>
 <p><strong>Dato for evaluering:</strong> {{oppfolgingsplan.evaluationDate}}</p>
-{{#if oppfolgingsplan.stillingstittel}}
-    <p><strong>Stilling:</strong> {{oppfolgingsplan.stillingstittel}} i {{oppfolgingsplan.organisasjonsnavn}}{{#if oppfolgingsplan.stillingsprosent}} i {{oppfolgingsplan.stillingsprosent}}% stilling{{/if}}</p>
-{{/if}}
 <p><strong>Arbeidstakers navn:</strong> {{oppfolgingsplan.sykmeldtName}}</p>
 <p><strong>Arbeidstakers fødselsnummer:</strong> {{oppfolgingsplan.sykmeldtFnr}}</p>
+{{#if oppfolgingsplan.stillingstittel}}
+    <p><strong>Stilling:</strong> {{oppfolgingsplan.stillingstittel}}{{#if oppfolgingsplan.stillingsprosent}} i {{oppfolgingsplan.stillingsprosent}}% stilling{{/if}}</p>
+{{/if}}
 <p><strong>Bedriftens navn:</strong> {{oppfolgingsplan.organisasjonsnavn}}</p>
 <p><strong>Organisasjonsnummer:</strong> {{oppfolgingsplan.organisasjonsnummer}}</p>
 <p><strong>Nærmeste leder:</strong> {{oppfolgingsplan.narmesteLederName}}</p>

--- a/templates/oppfolgingsplan/oppfolgingsplan_v1.hbs
+++ b/templates/oppfolgingsplan/oppfolgingsplan_v1.hbs
@@ -42,6 +42,9 @@
 
 <p><strong>Opprettet:</strong> {{oppfolgingsplan.createdDate}}</p>
 <p><strong>Dato for evaluering:</strong> {{oppfolgingsplan.evaluationDate}}</p>
+{{#if oppfolgingsplan.stillingstittel}}
+    <p><strong>Stilling:</strong> {{oppfolgingsplan.stillingstittel}} i {{oppfolgingsplan.organisasjonsnavn}}{{#if oppfolgingsplan.stillingsprosent}} i {{oppfolgingsplan.stillingsprosent}}% stilling{{/if}}</p>
+{{/if}}
 <p><strong>Arbeidstakers navn:</strong> {{oppfolgingsplan.sykmeldtName}}</p>
 <p><strong>Arbeidstakers fødselsnummer:</strong> {{oppfolgingsplan.sykmeldtFnr}}</p>
 <p><strong>Bedriftens navn:</strong> {{oppfolgingsplan.organisasjonsnavn}}</p>


### PR DESCRIPTION
## Beskrivelse

Viser stillingstittel og stillingsprosent i oppfolgingsplan-PDFen og oppdaterer eksempeldata.

Null-handtering matcher frontend:
- skjuler raden nar stillingstittel mangler
- viser kun tittel og organisasjon nar stillingsprosent mangler
- viser full tekst nar begge finnes

## Endringer

- oppdaterer `templates/oppfolgingsplan/oppfolgingsplan_v1.hbs`
- oppdaterer `data/oppfolgingsplan/oppfolgingsplan_v1.json`

Closes #155