### PR TITLE
Kartleggingsspm fritekst v2

### DIFF
--- a/data/kartlegging/utsending.json
+++ b/data/kartlegging/utsending.json
@@ -1,5 +1,6 @@
 {
   "brevdata": {
+    "skjemavariant": "FLERVALG_FRITEKST_V2",
     "createdAt": "01.09.2025"
   }
 }

--- a/templates/kartlegging/receipt.hbs
+++ b/templates/kartlegging/receipt.hbs
@@ -74,6 +74,7 @@
         .question-description {
             margin: 0 0 0.5rem 0;
             font-style: italic;
+            color: gray;
         }
 
         .question-separator {

--- a/templates/kartlegging/receipt.hbs
+++ b/templates/kartlegging/receipt.hbs
@@ -73,7 +73,6 @@
 
         .question-description {
             margin: 0 0 0.5rem 0;
-            font-style: italic;
             color: gray;
         }
 

--- a/templates/kartlegging/skjemavariant/flervalg-default.hbs
+++ b/templates/kartlegging/skjemavariant/flervalg-default.hbs
@@ -1,0 +1,60 @@
+<div class="summary-container">
+<div class="question-block">
+    <p class="question-label">
+        Hvor sannsynlig er det at du kommer tilbake i jobben du ble sykmeldt fra?
+    </p>
+    <div class="radio-buttons-container">
+        {{> kartlegging/partials/radioButton
+                value="false"
+                checkedIfValueEquals="true"
+                label="Jeg tror det er veldig sannsynlig"
+        }}
+        {{> kartlegging/partials/radioButton
+                value="false"
+                checkedIfValueEquals="true"
+                label="Jeg tror det er lite sannsynlig"
+        }}
+        {{> kartlegging/partials/radioButton
+                value="false"
+                checkedIfValueEquals="true"
+                label="Jeg er usikker"
+        }}
+    </div>
+
+    <hr class="question-separator" />
+
+    <p class="question-label">
+        Hvordan vil du beskrive samarbeidet og relasjonen mellom deg og arbeidsgiveren din?
+    </p>
+    <div class="radio-buttons-container">
+        {{> kartlegging/partials/radioButton
+                value="false"
+                checkedIfValueEquals="true"
+                label="Jeg opplever samarbeidet og relasjonen som god"
+        }}
+        {{> kartlegging/partials/radioButton
+                value="false"
+                checkedIfValueEquals="true"
+                label="Jeg opplever samarbeidet og relasjonen som dårlig"
+        }}
+    </div>
+    
+    <hr class="question-separator" />
+
+    <p class="question-label">
+        Hvor lenge tror du at du kommer til å være sykmeldt?
+    </p>
+    <div class="radio-buttons-container">
+        {{> kartlegging/partials/radioButton
+                value="false"
+                checkedIfValueEquals="true"
+                label="Mindre enn seks måneder"
+        }}
+        {{> kartlegging/partials/radioButton
+                value="false"
+                checkedIfValueEquals="true"
+                label="Mer enn seks måneder"
+        }}
+    </div>
+</div>
+</div>

--- a/templates/kartlegging/skjemavariant/flervalg-fritekst-v2.hbs
+++ b/templates/kartlegging/skjemavariant/flervalg-fritekst-v2.hbs
@@ -1,0 +1,65 @@
+<div class="summary-container">
+<div class="question-block">
+    <p class="question-label">
+        Hvor sannsynlig er det at du kommer tilbake i jobben du ble sykmeldt fra?
+    </p>
+    <div class="radio-buttons-container">
+        {{> kartlegging/partials/radioButton
+                value="false"
+                checkedIfValueEquals="true"
+                label="Jeg tror det er veldig sannsynlig"
+        }}
+        {{> kartlegging/partials/radioButton
+                value="false"
+                checkedIfValueEquals="true"
+                label="Jeg tror det er lite sannsynlig"
+        }}
+        {{> kartlegging/partials/radioButton
+                value="false"
+                checkedIfValueEquals="true"
+                label="Jeg er usikker"
+        }}
+    </div>
+
+    <hr class="question-separator" />
+
+    <p class="question-label">
+        Får du oppfølging av arbeidsgiveren din nå når du er sykmeldt?
+    </p>
+    <p class="question-description">
+        Arbeidsgiveren din har hovedansvaret for å gjøre tilpasninger og følge deg opp på arbeidsplassen.
+        Arbeidsgiver har for eksempel plikt til å lage en oppfølgingsplan med deg innen uke 4.
+        Derfor er det viktig at dere har tett kontakt når du er sykmeldt.
+    </p>
+    <div class="radio-buttons-container">
+        {{> kartlegging/partials/radioButton
+                value="false"
+                checkedIfValueEquals="true"
+                label="Ja, jeg får oppfølging, og har snakket med arbeidsgiver om dette."
+        }}
+        {{> kartlegging/partials/radioButton
+                value="false"
+                checkedIfValueEquals="true"
+                label="Nei, jeg opplever manglende oppfølging og at tilrettelegging er vanskelig "
+        }}
+    </div>
+
+    <hr class="question-separator" />
+
+    <p class="question-label">
+        Hvor lenge tror du at du kommer til å være sykmeldt?
+    </p>
+    <div class="radio-buttons-container">
+        {{> kartlegging/partials/radioButton
+                value="false"
+                checkedIfValueEquals="true"
+                label="Mindre enn seks måneder"
+        }}
+        {{> kartlegging/partials/radioButton
+                value="false"
+                checkedIfValueEquals="true"
+                label="Mer enn seks måneder"
+        }}
+    </div>
+</div>
+</div>

--- a/templates/kartlegging/utsending.hbs
+++ b/templates/kartlegging/utsending.hbs
@@ -16,7 +16,7 @@
         .summary-container { border-radius: 4px; padding: 0.25rem 1rem; }
         .question-block { margin: 0 0 1.25rem 0; }
         .question-label { margin: 0 0 0.5rem 0; font-weight: 600; }
-        .question-description { margin: 0 0 0.5rem 0; }
+        .question-description { margin: 0 0 0.5rem 0; font-style: italic; }
         .info-box {
             border: 1px solid #457c9d;
             border-radius: 12px;
@@ -49,65 +49,17 @@
         </span>
     </p>
 
-    <div class="summary-container">
-    <div class="question-block">
-        <p class="question-label">
-            Hvor sannsynlig er det at du kommer tilbake i jobben du ble sykmeldt fra?
-        </p>
-        <div class="radio-buttons-container">
-            {{> kartlegging/partials/radioButton
-                    value="false"
-                    checkedIfValueEquals="true"
-                    label="Jeg tror det er veldig sannsynlig"
-            }}
-            {{> kartlegging/partials/radioButton
-                    value="false"
-                    checkedIfValueEquals="true"
-                    label="Jeg tror det er lite sannsynlig"
-            }}
-            {{> kartlegging/partials/radioButton
-                    value="false"
-                    checkedIfValueEquals="true"
-                    label="Jeg er usikker"
-            }}
-        </div>
-
-        <hr class="question-separator" />
-
-        <p class="question-label">
-            Hvordan vil du beskrive samarbeidet og relasjonen mellom deg og arbeidsgiveren din?
-        </p>
-        <div class="radio-buttons-container">
-            {{> kartlegging/partials/radioButton
-                    value="false"
-                    checkedIfValueEquals="true"
-                    label="Jeg opplever samarbeidet og relasjonen som god"
-            }}
-            {{> kartlegging/partials/radioButton
-                    value="false"
-                    checkedIfValueEquals="true"
-                    label="Jeg opplever samarbeidet og relasjonen som dårlig"
-            }}
-        </div>
-        
-        <hr class="question-separator" />
-
-        <p class="question-label">
-            Hvor lenge tror du at du kommer til å være sykmeldt?
-        </p>
-        <div class="radio-buttons-container">
-            {{> kartlegging/partials/radioButton
-                    value="false"
-                    checkedIfValueEquals="true"
-                    label="Mindre enn seks måneder"
-            }}
-            {{> kartlegging/partials/radioButton
-                    value="false"
-                    checkedIfValueEquals="true"
-                    label="Mer enn seks måneder"
-            }}
-        </div>
-    </div>
-    </div>
+    {{#eq brevdata.skjemavariant null}}
+        {{> kartlegging/skjemavariant/flervalg-default}}
+    {{/eq}}
+    {{#eq brevdata.skjemavariant "FLERVALG_V1"}}
+        {{> kartlegging/skjemavariant/flervalg-default}}
+    {{/eq}}
+    {{#eq brevdata.skjemavariant "FLERVALG_FRITEKST_V1"}}
+        {{> kartlegging/skjemavariant/flervalg-default}}
+    {{/eq}}
+    {{#eq brevdata.skjemavariant "FLERVALG_FRITEKST_V2"}}
+        {{> kartlegging/skjemavariant/flervalg-fritekst-v2}}
+    {{/eq}}
 </body>
 </html>

--- a/templates/kartlegging/utsending.hbs
+++ b/templates/kartlegging/utsending.hbs
@@ -16,7 +16,7 @@
         .summary-container { border-radius: 4px; padding: 0.25rem 1rem; }
         .question-block { margin: 0 0 1.25rem 0; }
         .question-label { margin: 0 0 0.5rem 0; font-weight: 600; }
-        .question-description { margin: 0 0 0.5rem 0; font-style: italic; }
+        .question-description { margin: 0 0 0.5rem 0; font-style: italic; color: grey; }
         .info-box {
             border: 1px solid #457c9d;
             border-radius: 12px;

--- a/templates/kartlegging/utsending.hbs
+++ b/templates/kartlegging/utsending.hbs
@@ -16,7 +16,7 @@
         .summary-container { border-radius: 4px; padding: 0.25rem 1rem; }
         .question-block { margin: 0 0 1.25rem 0; }
         .question-label { margin: 0 0 0.5rem 0; font-weight: 600; }
-        .question-description { margin: 0 0 0.5rem 0; font-style: italic; color: grey; }
+        .question-description { margin: 0 0 0.5rem 0; color: grey; }
         .info-box {
             border: 1px solid #457c9d;
             border-radius: 12px;


### PR DESCRIPTION
Støtte for skjemavariant FLERVALG_FRITEKST_V2. 
Denne varianten har en annen ordlyd på spørsmål 2, og vi må derfor ha en annen mal for journalføringen som blir gjort ved utsending av kartleggingspørsmålene.
Se https://github.com/navikt/ismeroppfolging/pull/254 for hvordan malen brukes.

<img width="996" height="1253" alt="Skjermbilde 2026-05-20 kl  07 36 50" src="https://github.com/user-attachments/assets/304c9d1f-baf1-487f-9e16-3817872ca649" />