### PR TITLE
Upgrade the pdfgen base image to 2.0.120

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/navikt/pdfgen:2.0.117
+FROM ghcr.io/navikt/pdfgen:2.0.120
 LABEL org.opencontainers.image.source=https://github.com/navikt/syfooppdfgen
 
 COPY templates /app/templates


### PR DESCRIPTION
## Beskrivelse

Oppdaterer base image

## Endringer

- `dockerFile`: endrer versjon for base image til `navikt/pdfgen` siste versjon 2.0.120

## Issue

Ingen issue. Gjelder kritiske sårbarhetsfunn fra Google Cloud scanner.

## Sjekkliste

- [x] Koden kompilerer og linter uten feil (`./gradlew --no-daemon build`)
- [x] Ingen sensitiv data eksponert (tokens, credentials, PII)