### PR TITLE
fix: increase memory limit to 750Mi

### DIFF
--- a/.nais/naiserator.yaml
+++ b/.nais/naiserator.yaml
@@ -38,7 +38,7 @@ spec:
   resources:
     limits:
       cpu: 1000m
-      memory: 512Mi
+      memory: 750Mi
     requests:
       cpu: 500m
       memory: 256Mi


### PR DESCRIPTION
Appen har vært på limit og har ført til crash i syfo-oppfolgingsplan-backend. 